### PR TITLE
Don't write to stderr if PIL was not detected

### DIFF
--- a/barcode/writer.py
+++ b/barcode/writer.py
@@ -14,8 +14,9 @@ except ImportError:
     try:
         from PIL import Image, ImageDraw, ImageFont  # lint:ok
     except ImportError:
-        import sys
-        sys.stderr.write('PIL not found. Image output disabled.\n\n')
+        import logging
+        log = logging.getLogger('barcode')
+        log.info('PIL not found. Image output disabled.')
         Image = ImageDraw = ImageFont = None  # lint:ok
 
 


### PR DESCRIPTION
It's a valid use case to use svg's only.