### PR TITLE
Support for PIL image writer in python 3

### DIFF
--- a/barcode/base.py
+++ b/barcode/base.py
@@ -79,7 +79,7 @@ class Barcode(object):
                 The same as in `self.render`.
         """
         output = self.render(options)
-        if hasattr(output, 'tostring'):
+        if hasattr(output, 'tostring') or hasattr(output, 'tobytes'):
             output.save(fp, format=self.writer.format)
         else:
             fp.write(output)


### PR DESCRIPTION
In python3, the PIL Image object has no `tostring` method but a `tobytes` method